### PR TITLE
Add Kindle Highlights Exporter to Manager section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Suggestions and contributions are welcome.
 * [Calibre](https://github.com/kovidgoyal/calibre) - A famous ebook manager.
 * [Kindle-highlights](https://github.com/speric/kindle-highlights) - A Ruby gem for collecting your Kindle hightlights. 
 * [kindle2notion](https://github.com/paperboi/kindle2notion) - A program to copy all your Kindle highlights and notes to a page in Notion.
+* [Kindle Highlights Exporter](https://xueboyang1985.github.io/kindle-exporter/) - A browser-based tool to export Kindle highlights to Markdown, CSV, or JSON. 100% local, no upload required.
 ### Generator
 * [KindleEar](https://github.com/cdhigh/KindleEar) - An app to aggergate RSS for generating periodical mobi/epub file and send it automatically.
 * [Kindle Comic Converter](https://github.com/ciromattia/kcc) ([Official](https://kcc.iosphe.re/)) - A Python app to convert comic files to e-books.


### PR DESCRIPTION
## Add Kindle Highlights Exporter

A browser-based tool to export Kindle highlights and notes to Markdown, CSV, or JSON. 100% local, no upload required.

**Link**: https://xueboyang1985.github.io/kindle-exporter/
**Repository**: https://github.com/xueboyang1985/kindle-exporter